### PR TITLE
feat: 카카오 로그인 api 완성

### DIFF
--- a/src/auth/auth.resolver.ts
+++ b/src/auth/auth.resolver.ts
@@ -23,7 +23,6 @@ export class AuthResolver {
 
   @Mutation('kakaoLogin')
   async kakaoLogin(context: object, @Args('accessToken') accessToken: string): Promise<string> {
-    await this.authService.kakaoLogin(accessToken, this.userService);
-    return 'YES'
+    return await this.authService.kakaoLogin(accessToken, this.userService);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -30,7 +30,7 @@ export class AuthService {
         const userInfo: object = await userService.checkNewUser(JSON.parse(result).response.id, 'naver');
         return await this.createToken(userInfo);
       } else {
-        return 'naver openAPI error:' + response.statusText;
+        return 'naver login openAPI error: ' + response.statusText;
       }
     } catch(e) {
       throw new Error(e);
@@ -43,28 +43,22 @@ export class AuthService {
       method: 'GET',
       headers: { 'Authorization': `Bearer ${accessToken}` }
     })
-
     const result = await response.text();
 
-    console.log('response >', response);
-    console.log('result >', result);
-
     // 회원가입 및 로그인
-    // try {
-    //   if (response.status === 200) {
-    //     const userInfo: object = await userService.checkNewUser(JSON.parse(result).response.id, 'naver');
-    //     return await this.createToken(userInfo);
-    //   } else {
-    //     return 'naver openAPI error:' + response.statusText;
-    //   }
-    // } catch(e) {
-    //   throw new Error(e);
-    // }
-    return 'YES'
+    try {
+      if (response.status === 200) {
+        const userInfo: object = await userService.checkNewUser(JSON.parse(result).id, 'kakao');
+        return await this.createToken(userInfo);
+      } else {
+        return 'kakao login openAPI error: ' + response.statusText;
+      }
+    } catch(e) {
+      throw new Error(e);
+    }
   }
 
   public async createToken(userInfo: any): Promise<string> {
-    console.info(userInfo.userIndex);
     return this.jwtService.sign({userIndex: userInfo.userIndex});
   }
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -49,21 +49,48 @@ export class UserService {
         throw new Error(e);
       }
     }
+    else if (loginType === "kakao") {
+      try {
+        const [data] = await this.userRepository.find({
+          select: ["userIndex"],
+          where: { kakaoID: userID }
+        });
+        // 이미 가입한 유저
+        if (data !== undefined) {
+          return { status: "login", userIndex: data.userIndex };
+        }
+        // 새로 가입하는 유저
+        else {
+          const userIndex = await this.addNewUser(userID, loginType);
+          return { status: "join", userIndex: userIndex };
+        }
+      } catch (e) {
+        throw new Error(e);
+      }
+    }
   }
 
   public async addNewUser(userID, loginType): Promise<number> {
     try {
       if (loginType === "naver") {
         const newName = this.makeDefaultName();
-        await this.userRepository.save({
+        const newUser = await this.userRepository.save({
           userName: await this.makeDefaultName(),
           naverID: userID
         });
+        return newUser.userIndex;
+      }
+      else if (loginType === "kakao") {
+        const newName = this.makeDefaultName();
+        const newUser = await this.userRepository.save({
+          userName: await this.makeDefaultName(),
+          kakaoID: userID
+        })
+        return newUser.userIndex;
       }
     } catch(e) {
       throw new Error(e);
     }
-    return 1;
   }
 
   public async makeDefaultName(): Promise<string> {


### PR DESCRIPTION
네이버 로그인과 카카오 로그인 api 구현 완료했습니다.
네이버/카카오 로그인 → 사용자 정보 조회 (userID 조회)
→ 로그인 시 JWT 토큰 리턴, 회원가입 시 유저 등록 후 JWT 토큰 리턴